### PR TITLE
Changes for padding part to in-line with ISC

### DIFF
--- a/dhcp4relay/src/dhcp4_sender.cpp
+++ b/dhcp4relay/src/dhcp4_sender.cpp
@@ -16,14 +16,15 @@
  * @param len                       length of message
  * @param src_ip                    source IP address as string (optional)
  * @param use_src_ip                if true, use src_ip as source address
+ * @param pad                       if true, do padding
  *
  * @return boolean   True if packet successfully sent
  */
 #ifndef UNIT_TEST
-bool send_udp(int sock, uint8_t *buffer, struct sockaddr_in target, uint32_t len, in_addr src_ip, bool use_src_ip) {
+bool send_udp(int sock, uint8_t *buffer, struct sockaddr_in target, uint32_t len, in_addr src_ip, bool use_src_ip, bool pad) {
    /* Pad additional bytes if length is lesser than 300
     * to make DHCP packet length to minimum of 300 bytes */
-   if (len < BOOTP_MIN_LEN) {
+   if (pad && len < BOOTP_MIN_LEN) {
       auto pad_len = BOOTP_MIN_LEN - len;
       memset(buffer+len, 0, pad_len);
       len = BOOTP_MIN_LEN;

--- a/dhcp4relay/src/dhcp4_sender.h
+++ b/dhcp4relay/src/dhcp4_sender.h
@@ -16,7 +16,8 @@
  * @param len                         length of message
  * @param src_ip                    source IP address as string (optional)
  * @param use_src_ip                if true, use src_ip as source address
+ * @param pad                       if true, do padding
  *
  * @return boolean   True if packet successfully sent
  */
-bool send_udp(int sock, uint8_t *buffer, struct sockaddr_in target, uint32_t len, in_addr src_ip, bool use_src_ip);
+bool send_udp(int sock, uint8_t *buffer, struct sockaddr_in target, uint32_t len, in_addr src_ip, bool use_src_ip, bool pad);

--- a/dhcp4relay/src/dhcp4relay.cpp
+++ b/dhcp4relay/src/dhcp4relay.cpp
@@ -577,7 +577,7 @@ void from_client(pcpp::DhcpLayer *dhcp_pkt, relay_config &config) {
     }
 
     for (auto server : config.servers_sock) {
-        if (send_udp(sock, (uint8_t *)dhcp_pkt->getDhcpHeader(), server, dhcp_pkt->getHeaderLen(), src_ip, use_intf_ip_as_src_ip)) {
+        if (send_udp(sock, (uint8_t *)dhcp_pkt->getDhcpHeader(), server, dhcp_pkt->getHeaderLen(), src_ip, use_intf_ip_as_src_ip, true)) {
             syslog(LOG_INFO, "[DHCPV4_RELAY] DHCP packet is sent to configured server: %s, interface: %s",
                    config.servers[index].c_str(), config.vlan.c_str());
             dhcp_cntr_table.increment_counter(config.vlan, "TX", (int)dhcp_pkt->getMessageType());
@@ -635,6 +635,7 @@ void to_client(pcpp::DhcpLayer *dhcp_pkt, std::unordered_map<std::string, relay_
     struct sockaddr_in target_addr = {0};
     uint32_t giaddr = dhcp_pkt->getDhcpHeader()->gatewayIpAddress;
     uint32_t broadcast_addr = DHCP_BROADCAST_IPADDR;
+    bool pad = false;
     std::unordered_map<std::string, relay_config>::iterator config_itr = vlans->end();
 
     if (getifaddrs(&ifa) == -1) {
@@ -731,8 +732,13 @@ void to_client(pcpp::DhcpLayer *dhcp_pkt, std::unordered_map<std::string, relay_
     in_addr ip_zero = {0};
     /* TODO: Send unicast message to client if BOOTP flag from client is set to unicast */
 
-    dhcp_pkt->removeOption(pcpp::DHCPOPT_DHCP_AGENT_OPTIONS);
-    if (send_udp(config.client_sock, (uint8_t *)dhcp_pkt->getDhcpHeader(), target_addr, dhcp_pkt->getHeaderLen(), ip_zero, false)) {
+    /* Perform padding only when DHCP relay (Option 82) information has been stripped from the packet */
+    if(dhcp_pkt->removeOption(pcpp::DHCPOPT_DHCP_AGENT_OPTIONS)) {
+        syslog(LOG_NOTICE, "Packet is stripped");
+        pad = true;
+    }
+
+    if (send_udp(config.client_sock, (uint8_t *)dhcp_pkt->getDhcpHeader(), target_addr, dhcp_pkt->getHeaderLen(), ip_zero, false, pad)) {
         syslog(LOG_INFO, "[DHCPV4_RELAY] dhcp relay message is broadcast to client %s from server %s",
                config.vlan.c_str(), src_ip.c_str());
         dhcp_cntr_table.increment_counter(config.vlan, "TX", (int)dhcp_pkt->getMessageType());

--- a/dhcp4relay/test/mock_relay.cpp
+++ b/dhcp4relay/test/mock_relay.cpp
@@ -24,7 +24,7 @@ using namespace swss;
 MOCK_GLOBAL_FUNC1(getifaddrs, int(struct ifaddrs **));
 MOCK_GLOBAL_FUNC1(freeifaddrs, void(struct ifaddrs *));
 MOCK_GLOBAL_FUNC3(write, ssize_t(int, const void*, size_t));
-MOCK_GLOBAL_FUNC6(send_udp, bool(int, uint8_t *, struct sockaddr_in, uint32_t, in_addr, bool));
+MOCK_GLOBAL_FUNC7(send_udp, bool(int, uint8_t *, struct sockaddr_in, uint32_t, in_addr, bool, bool));
 
 void encode_relay_option(pcpp::DhcpLayer *dhcp_pkt, relay_config *config);
 void to_client(pcpp::DhcpLayer* dhcp_pkt, std::unordered_map<std::string, relay_config > *vlans,
@@ -851,8 +851,8 @@ TEST(DHCPRelayTest, to_client) {
     struct ifaddrs *mock_ifaddrs = CreateMockIfaddrs("192.168.1.1", "255.255.255.0", "Vlan100", "192.168.1.2", "Ethernet4");
     EXPECT_GLOBAL_CALL(getifaddrs, getifaddrs(_)).WillOnce(DoAll(testing::SetArgPointee<0>(mock_ifaddrs), Return(0)));
     EXPECT_GLOBAL_CALL(freeifaddrs, freeifaddrs(_)).Times(1);
-    EXPECT_GLOBAL_CALL(send_udp, send_udp(_, _, _, _, _, _)).WillOnce([]
-		(int sock, uint8_t* hdr, struct sockaddr_in target, uint32_t len, in_addr src_ip, bool use_src_ip) {
+    EXPECT_GLOBAL_CALL(send_udp, send_udp(_, _, _, _, _, _, _)).WillOnce([]
+		(int sock, uint8_t* hdr, struct sockaddr_in target, uint32_t len, in_addr src_ip, bool use_src_ip, bool pad) {
         pcpp::dhcp_header* dhcp_hdr = (pcpp::dhcp_header*)hdr;
         EXPECT_EQ((dhcp_hdr->opCode), 1);
         EXPECT_EQ((dhcp_hdr->hops), 1);
@@ -891,8 +891,8 @@ TEST(DHCPRelayTest, from_client) {
     m_config.host_mac_addr = "12:32:54:24:95:36";
     encode_relay_option(&dhcpLayer, &config);
 
-    EXPECT_GLOBAL_CALL(send_udp, send_udp(_, _, _, _, _, _)).WillOnce([]
-		    (int sock, uint8_t* hdr, struct sockaddr_in target, uint32_t len, in_addr src_ip, bool use_src_ip) {
+    EXPECT_GLOBAL_CALL(send_udp, send_udp(_, _, _, _, _, _, _)).WillOnce([]
+		    (int sock, uint8_t* hdr, struct sockaddr_in target, uint32_t len, in_addr src_ip, bool use_src_ip, bool pad) {
         pcpp::dhcp_header* dhcp_hdr = (pcpp::dhcp_header*)hdr;
         EXPECT_EQ((dhcp_hdr->opCode), 0);
         EXPECT_EQ((dhcp_hdr->hops), 1);


### PR DESCRIPTION
**ISC Padding Behavior**
	•	Client → Relay → Server:
Padding is not applied if the packet is invalid or if the forward_untouched mode is enabled.
In all other cases, padding is added when the packet length is less than 300 bytes.
	•	Server → Relay → Client:
Padding is not applied if the relay does not strip the relay (Option 82) information from the packet.
Otherwise, padding is added before sending the packet to the client.

**New DHCPv4 Padding Behavior**
Padding is determined solely based on the packet size (excluding headers).
If the packet length is less than 300 bytes (BOOTP_MIN_LEN), padding is always added, with no exceptions.

**SONiC Management:**
Tests The SONiC management test suite uses TestUtils to construct and send DHCP packets.
In certain test scenarios, the generated packets do not include DHCP relay (Option 82) information

The following packet was constructed by TestUtils to simulate a server response in the failure scenario.
It does not include any DHCP relay (Option 82) information:

02 CE 38 77 91 AD 02 99 E1 EC 30 1C 08 00 45 00 01 10 00 00 00 00 80 11 B9 32 C0 00 00 01 C0 A8 00 01 00 43 00 43 00 FC BA FF 02 01 06 00 00 00 00 00 00 00 80 00 00 00 00 00 C0 A8 00 02 C0 00 00 01 C0 A8 00 01 02 77 2E 0F D0 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 63 82 53 63 35 01 0B FF

Since this packet does not contain Option 82 fields, the ISC DHCP relay will not perform padding.


**Below changes are done:**

to_client()
This function handles packets flowing from the server to the client.
	•	The function should verify whether relay (Option 82) information has been stripped from the packet.
	•	If the relay options are stripped, padding must be applied before forwarding the packet to the client.
	•	If the relay options are not stripped, padding is not required.

from_client()
This function handles packets flowing from the client to the server.
	•	In this direction, there is no forward_untouched mode in the relay agent configuration.
	•	Therefore, no exceptions need to be applied — padding should be performed when the packet size is below the minimum threshold (300 bytes).
